### PR TITLE
Support Service Principal with access to multiple subscriptions

### DIFF
--- a/buildagent-generation.yml
+++ b/buildagent-generation.yml
@@ -166,6 +166,7 @@ jobs:
       arguments: -ClientId $(CLIENT_ID) `
                         -ClientSecret $(CLIENT_SECRET) `
                         -ResourceGroup $(AZURE_AGENTS_RESOURCE_GROUP) `
+                        -SubscriptionId $(AZURE_SUBSCRIPTION) `
                         -TenantId $(AZURE_TENANT) `
                         -VmssName $(VmssName) `
                         -ManagedImageId $(ManagedImageId)

--- a/scripts/cleanup-managedimages.ps1
+++ b/scripts/cleanup-managedimages.ps1
@@ -10,6 +10,7 @@ param(
 )
 
 az login --service-principal --username $ClientId --password $ClientSecret --tenant $TenantId | Out-Null
+az account set -s $SubscriptionId
 
 $managedImages = az image list --resource-group $ResourceGroup --subscription $SubscriptionId --query "[].id" | Out-String | ConvertFrom-Json
 

--- a/scripts/cleanup.ps1
+++ b/scripts/cleanup.ps1
@@ -9,6 +9,7 @@ param(
 )
 
 az login --service-principal --username $ClientId --password $ClientSecret --tenant $TenantId | Out-Null
+az account set -s $SubscriptionId
 
 $TempResourceGroupName = "${ResourcesNamePrefix}_${Image}"
 

--- a/scripts/create-managedimage.ps1
+++ b/scripts/create-managedimage.ps1
@@ -13,6 +13,7 @@ param(
 )
 
 az login --service-principal --username $ClientId --password $ClientSecret --tenant $TenantId | Out-Null
+az account set -s $SubscriptionId
 
 $imageName = "$ImageType-$ResourcesNamePrefix"
 $managedImageId = az image create -g $ResourceGroup -n $imageName --location $Location --os-type $OsType --source $OsVhdUri --query 'id'

--- a/scripts/update-vmss.ps1
+++ b/scripts/update-vmss.ps1
@@ -2,12 +2,14 @@ param(
     [String] [Parameter (Mandatory=$true)] $ClientId,
     [String] [Parameter (Mandatory=$true)] $ClientSecret,
     [String] [Parameter (Mandatory=$true)] $TenantId,
+    [String] [Parameter (Mandatory=$true)] $SubscriptionId,
     [String] [Parameter (Mandatory=$true)] $ResourceGroup,
     [String] [Parameter (Mandatory=$true)] $VmssName,
     [String] [Parameter (Mandatory=$true)] $ManagedImageId
 )
 
 az login --service-principal --username $ClientId --password $ClientSecret --tenant $TenantId | Out-Null
+az account set -s $SubscriptionId
 
 az vmss update --resource-group $ResourceGroup --name $VmssName --set virtualMachineProfile.storageProfile.imageReference.id=$ManagedImageId
 Write-Host "Updated Virtual Machine Scale Set with new Azure Image: $ManagedImageId"


### PR DESCRIPTION
If the configured Service Principal you're using has a different DEFAULT Azure subscription than the one used in the automation, these pipelines fail.

This PR explicitly sets the configured Subscription after each az login.