### PR TITLE
updated readme reference to match cloned virtual environment repo 

### DIFF
--- a/buildagent-generation.yml
+++ b/buildagent-generation.yml
@@ -45,7 +45,7 @@ jobs:
         $OsType = if ($ImageType.StartsWith("ubuntu")) { "Linux" } else { "Windows" }
         $TemplateDirectoryPath = Join-Path (Join-Path "virtual-environments" "images") $TemplateDirectoryName | Resolve-Path
         $TemplatePath = Join-Path $TemplateDirectoryPath "$ImageType.json"
-        $ImageReadmeNameConcat = "${{ parameters.image_type }}-README.md"
+        $ImageReadmeNameConcat = "${{ parameters.image_type }}-Readme.md"
         $ImageReadmeName = $ImageReadmeNameConcat.Substring(0,1).ToUpper()+$ImageReadmeNameConcat.Substring(1)
         Write-Host "##vso[task.setvariable variable=TemplateDirectoryPath;]$TemplateDirectoryPath"
         Write-Host "##vso[task.setvariable variable=TemplatePath;]$TemplatePath"


### PR DESCRIPTION
The virtual environments repo has changed its casing for readme.md files. When generating the linux build image, this was causing the pipeline to fail because it could not find README.md (the cloned file is Readme.md)

I have tested this fix which worked and updated the build agent pipeline to reflect this. 

