### PR TITLE
Support comma seperated list of vmss when updating

### DIFF
--- a/buildagent-generation-template.yml
+++ b/buildagent-generation-template.yml
@@ -185,7 +185,7 @@ jobs:
     - name: VmssName
       value: $[variables.VMSS_Ubuntu2004]
   - ${{ if eq(parameters.image_type, 'ubuntu2204') }}:
-    - name: VmssName
+    - name: VmssNames
       value: $[variables.VMSS_Ubuntu2204]
 
   steps:
@@ -202,5 +202,5 @@ jobs:
                         -ResourceGroup $(AZURE_AGENTS_RESOURCE_GROUP) `
                         -SubscriptionId $(AZURE_SUBSCRIPTION) `
                         -TenantId $(AZURE_TENANT) `
-                        -VmssName $(VmssName) `
+                        -VmssNames $(VmssNames) `
                         -ManagedImageId $(ManagedImageId)

--- a/buildagent-generation-template.yml
+++ b/buildagent-generation-template.yml
@@ -176,13 +176,13 @@ jobs:
     value: $[ dependencies.managedimagegeneration.outputs['createmanagedimage.ManagedImageId'] ]
   - group: ${{ parameters.variable_group }}
   - ${{ if eq(parameters.image_type, 'windows2019') }}:
-    - name: VmssName
+    - name: VmssNames
       value: $[variables.VMSS_Windows2019]
   - ${{ if eq(parameters.image_type, 'windows2022') }}:
-    - name: VmssName
+    - name: VmssNames
       value: $[variables.VMSS_Windows2022]
   - ${{ if eq(parameters.image_type, 'ubuntu2004') }}:
-    - name: VmssName
+    - name: VmssNames
       value: $[variables.VMSS_Ubuntu2004]
   - ${{ if eq(parameters.image_type, 'ubuntu2204') }}:
     - name: VmssNames

--- a/scripts/update-vmss.ps1
+++ b/scripts/update-vmss.ps1
@@ -4,12 +4,15 @@ param(
     [String] [Parameter (Mandatory=$true)] $TenantId,
     [String] [Parameter (Mandatory=$true)] $SubscriptionId,
     [String] [Parameter (Mandatory=$true)] $ResourceGroup,
-    [String] [Parameter (Mandatory=$true)] $VmssName,
+    [String] [Parameter (Mandatory=$true)] $VmssNames,
     [String] [Parameter (Mandatory=$true)] $ManagedImageId
 )
 
 az login --service-principal --username $ClientId --password $ClientSecret --tenant $TenantId | Out-Null
 az account set -s $SubscriptionId
 
-az vmss update --resource-group $ResourceGroup --name $VmssName --set virtualMachineProfile.storageProfile.imageReference.id=$ManagedImageId
-Write-Host "Updated Virtual Machine Scale Set with new Azure Image: $ManagedImageId"
+$VmssNames.Split(",") | ForEach {
+  $VmssName = $_
+  az vmss update --resource-group $ResourceGroup --name $VmssName --set virtualMachineProfile.storageProfile.imageReference.id=$ManagedImageId
+  Write-Host "Updated Virtual Machine Scale Set ManagedImageId: $VmssName - $ManagedImageId"
+}


### PR DESCRIPTION
In our environment we have several vmss using the same managed image. This small addition will allow this pipeline to update them all