### PR TITLE
gallery_images_to_keep instead of gallery_threshold

### DIFF
--- a/managedimage-cleanup-galleryvm.yml
+++ b/managedimage-cleanup-galleryvm.yml
@@ -1,5 +1,3 @@
-trigger: none
-
 parameters:
 - name: variable_group
   displayName: Variable Group

--- a/managedimage-cleanup-template.yml
+++ b/managedimage-cleanup-template.yml
@@ -14,7 +14,7 @@ parameters:
   values:
   - galleryvm
   - vmss
-- name: gallery_threshold
+- name: gallery_images_to_keep
   displayName: Number of image versions to keep in gallery
   type: number
   default: 3
@@ -33,7 +33,7 @@ stages:
       variable_group: ${{ parameters.variable_group }}
       agent_pool: ${{ parameters.agent_pool }}
       repository_base_path: ${{ parameters.repository_base_path }}
-      gallery_threshold: ${{ parameters.gallery_threshold }}
+      gallery_images_to_keep: ${{ parameters.gallery_images_to_keep }}
 
 - stage: delete_vmss_imagevm
   displayName:  'Delete orphaned Managed Images'

--- a/managedimage-cleanup.yml
+++ b/managedimage-cleanup.yml
@@ -32,5 +32,5 @@ stages:
   parameters:
     variable_group: ${{ parameters.variable_group }}
     delete_type: ${{ parameters.delete_type }}
-    gallery_threshold: 3
+    gallery_images_to_keep: 3
     agent_pool: 'Azure Pipelines'


### PR DESCRIPTION
- trigger should not be present in the child template (managedimage-cleanup-galleryvm.yml)
- expected in the last template is gallery_images_to_keep instead of gallery_threshold