### PR TITLE
move depends_on parameter into first stage

### DIFF
--- a/buildagent-generation-template.yml
+++ b/buildagent-generation-template.yml
@@ -26,7 +26,7 @@ parameters:
       - prerelease
       - release
   - name: depends_on
-    displayName: First Job Depends On
+    displayName: First Stage Depends On
     type: object
     default: ' '
   - name: repository_base_path
@@ -44,11 +44,11 @@ parameters:
 stages:
   - stage: buildagent_template_vm
     displayName: 'Build Agent Template VM'
+    ${{ if ne(parameters.depends_on, ' ') }}:
+      dependsOn: ${{ parameters.depends_on }}
     jobs:
       - job: generate_image
         displayName: Image Generation (${{ parameters.image_type }})
-        ${{ if ne(parameters.depends_on, ' ') }}:
-          dependsOn: ${{ parameters.depends_on }}
         timeoutInMinutes: '600'
         cancelTimeoutInMinutes: '30'
         variables:


### PR DESCRIPTION
Having depends_on in the first job is of limited use since we can not add jobs into the same stage.

When trying to use it I got an error saying there must be at least one job in the first stage without dependencies.

Putting it in the stage instead allows this to work and us to dictate stages/jobs which come before it.