### PR TITLE
Remove unused parameter preventing gallery cleanup

### DIFF
--- a/managedimage-cleanup-galleryvm.yml
+++ b/managedimage-cleanup-galleryvm.yml
@@ -38,7 +38,6 @@ jobs:
                  -ClientSecret $(CLIENT_SECRET) `
                  -SubscriptionId $(AZURE_SUBSCRIPTION) `
                  -TenantId $(AZURE_TENANT) `
-                 -ResourceGroup $(AZURE_AGENTS_RESOURCE_GROUP) `
                  -GalleryName $(GALLERY_NAME) `
                  -GalleryResourceGroup $(GALLERY_RESOURCE_GROUP) `
                  -GalleryImagesToKeep ${{ parameters.gallery_images_to_keep }}

--- a/scripts/cleanup-gallery-vmimageversion.ps1
+++ b/scripts/cleanup-gallery-vmimageversion.ps1
@@ -3,7 +3,6 @@ param(
     [String] [Parameter (Mandatory=$true)] $ClientSecret,
     [String] [Parameter (Mandatory=$true)] $SubscriptionId,
     [String] [Parameter (Mandatory=$true)] $TenantId,
-    [String] [Parameter (Mandatory=$true)] $ResourceGroup,
     [String] [Parameter (Mandatory=$true)] $GalleryName,
     [String] [Parameter (Mandatory=$true)] $GalleryResourceGroup,
     [int] [Parameter (Mandatory=$true)] $GalleryImagesToKeep 


### PR DESCRIPTION
Hi Yannick,

Found a small bug in the cleanup pipeline. I'm performing cleanups on a SIG. They initially failed because the $ResourceGroup parameter was not set. I found out this parameter is only needed for the VMSS cleanups part, so it can be removed from the gallery part of the pipeline.

Thanks for considering.
Robbert 